### PR TITLE
navigator.id.getVerifiedEmail() is deprecated in favor of navigator.id.get();

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To better integrate BrowserID with your application, you will want to use the Br
     <script src="https://browserid.org/include.js" type="text/javascript"></script>
     <script type='text/javascript'>
       function loginViaEmail() {
-        navigator.id.getVerifiedEmail(function(assertion) {
+        navigator.id.get(function(assertion) {
           if (assertion) {
             $('input[name=assertion]').val(assertion);
             $('#browser_id_form').submit();

--- a/lib/omniauth/strategies/browser_id.rb
+++ b/lib/omniauth/strategies/browser_id.rb
@@ -33,7 +33,7 @@ module OmniAuth
             <script src="https://browserid.org/include.js" type="text/javascript"></script>
             <script type='text/javascript'>
               function loginViaEmail() {
-                navigator.id.getVerifiedEmail(function(assertion) {
+                navigator.id.get(function(assertion) {
                   if (assertion) {
                     $('input[name=assertion]').val(assertion);
                     $('form').submit();


### PR DESCRIPTION
See: https://developer.mozilla.org/en/DOM/navigator.id.getVerifiedEmail
