### PR TITLE
Add client_options option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To better integrate BrowserID with your application, you will want to use the Br
           } else {
             window.location = "#{failure_path}"
           }
-        });  
+        });
       }
 
       $(function() {
@@ -69,6 +69,7 @@ These are the options you can specify that are relevant to Omniauth BrowserID:
 * `:verify_url` - The verifier URL (defaults to `https://browserid.org/verify`)
 * `:name` - The URL at which the strategy will be available (defaults to `browser_id`)
 * `:audience_url` - The host of your site. Defaults to the `full_host` of OmniAuth (either automatically determined or determined by the `OmniAuth.config.full_host` option)
+* `:client_options` - Any additional options to send to the Faraday connection.
 
 ## License
 

--- a/lib/omniauth/strategies/browser_id.rb
+++ b/lib/omniauth/strategies/browser_id.rb
@@ -11,6 +11,7 @@ module OmniAuth
       option :verify_url, 'https://browserid.org/verify'
       option :name, 'browser_id'
       option :audience_url, nil
+      option :client_options, {}
 
       def other_phase
         if on_path?(failure_path)
@@ -40,7 +41,7 @@ module OmniAuth
                   } else {
                     window.location = "#{failure_path}"
                   }
-                });  
+                });
               }
 
               $(function() {
@@ -67,7 +68,7 @@ module OmniAuth
       end
 
       def raw_info
-        response = connection.post('', 
+        response = connection.post('',
           :assertion => request.params['assertion'],
           :audience => full_host
         )
@@ -76,7 +77,8 @@ module OmniAuth
       end
 
       def connection
-        resp = Faraday.new(:url => options[:verify_url])
+        Faraday.new(options[:client_options].
+          update(:url => options[:verify_url]))
       end
     end
   end


### PR DESCRIPTION
Will allow sending of other options to Faraday
connection, such as :ssl, which is necessary on
Ubuntu (see omniauth-facebook discussions on this
issue).
