### PR TITLE
Avoid blocking page rendering when loading external JS files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,12 @@ To better integrate BrowserID with your application, you will want to use the Br
 
 ```html
 <html>
-  <head>
+  <body>
+    <form id='browser_id_form' action='/auth/browser_id/callback'>
+      <input type='hidden' name='assertion'/>
+      <button type='submit'>Login with BrowserID</button>
+    </form>
+
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
     <script src="https://browserid.org/include.js" type="text/javascript"></script>
     <script type='text/javascript'>
@@ -50,12 +55,6 @@ To better integrate BrowserID with your application, you will want to use the Br
         });
       });
     </script>
-  </head>
-  <body>
-    <form id='browser_id_form' action='/auth/browser_id/callback'>
-      <input type='hidden' name='assertion'/>
-      <button type='submit'>Login with BrowserID</button>
-    </form>
   </body>
 </html>
 ```


### PR DESCRIPTION
To enable browsers to continue to rendering the page without
blocking when they encounter these external Javascript files, it's
better to move scripts to the bottom of the page.

This change only modifies the recommended code in the README.
