### PR TITLE
Use different failure url to avoid infinite redirect loop

### DIFF
--- a/lib/omniauth/strategies/browser_id.rb
+++ b/lib/omniauth/strategies/browser_id.rb
@@ -22,7 +22,7 @@ module OmniAuth
       end
 
       def failure_path
-        options[:failure_path] || "#{path_prefix}/failure"
+        options[:failure_path] || "#{path_prefix}/redirect_failure"
       end
 
       def request_phase


### PR DESCRIPTION
Persona strategy was grabbing other strategies' failure and then entering into a infinite redirect loop.

This uses a temporary failure path different from the default failure path. 
